### PR TITLE
Bump web-component-tester to 6.1.5

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,6 +33,6 @@
     "iron-component-page": "^3.0.0",
     "iron-demo-helpers": "^2.0.0",
     "iron-test-helpers": "^2.0.0",
-    "web-component-tester": "^6.0.0"
+    "web-component-tester": "^6.1.5"
   }
 }


### PR DESCRIPTION
Connected to https://github.com/vaadin/vaadin-core/issues/127

Bump web-component-tester to 6.1.5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-checkbox/32)
<!-- Reviewable:end -->
