### PR TITLE
Revert "Set checked to false on indeterminate changed"

### DIFF
--- a/test/vaadin-checkbox_test.html
+++ b/test/vaadin-checkbox_test.html
@@ -141,32 +141,6 @@
         expect(vaadinCheckbox.hasAttribute('active')).to.be.false;
       });
 
-      it('should not be checked when indeterminate is true', () => {
-        vaadinCheckbox.checked = false;
-        vaadinCheckbox.indeterminate = true;
-
-        expect(vaadinCheckbox.checked).to.be.false;
-        expect(vaadinCheckbox.getAttribute('aria-checked')).to.be.eql('mixed');
-      });
-
-      it('should uncheck when indeterminate is true', () => {
-        vaadinCheckbox.checked = true;
-        vaadinCheckbox.indeterminate = true;
-
-        expect(vaadinCheckbox.checked).to.be.false;
-        expect(vaadinCheckbox.getAttribute('aria-checked')).to.be.eql('mixed');
-      });
-
-      it('should be checked after toggling indeterminate to true and back to false', () => {
-        vaadinCheckbox.checked = false;
-        vaadinCheckbox.indeterminate = true;
-        vaadinCheckbox.indeterminate = false;
-
-        expect(vaadinCheckbox.checked).to.be.true;
-        expect(vaadinCheckbox.indeterminate).to.be.false;
-        expect(vaadinCheckbox.getAttribute('aria-checked')).to.be.eql('true');
-      });
-
       it('should be checked after space when initially checked is false and indeterminate is true', () => {
         vaadinCheckbox.checked = false;
         vaadinCheckbox.indeterminate = true;
@@ -179,16 +153,16 @@
         expect(vaadinCheckbox.getAttribute('aria-checked')).to.be.eql('true');
       });
 
-      it('should be checked after space when initially checked is true and indeterminate is true', () => {
+      it('should not be checked after space when initially checked is true and indeterminate is true', () => {
         vaadinCheckbox.checked = true;
         vaadinCheckbox.indeterminate = true;
 
         MockInteractions.keyDownOn(vaadinCheckbox, 32);
         MockInteractions.keyUpOn(vaadinCheckbox, 32);
 
-        expect(vaadinCheckbox.checked).to.be.true;
+        expect(vaadinCheckbox.checked).to.be.false;
         expect(vaadinCheckbox.indeterminate).to.be.false;
-        expect(vaadinCheckbox.getAttribute('aria-checked')).to.be.eql('true');
+        expect(vaadinCheckbox.getAttribute('aria-checked')).to.be.eql('false');
       });
     });
   </script>

--- a/vaadin-checkbox.html
+++ b/vaadin-checkbox.html
@@ -192,21 +192,11 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
-        _indeterminateChanged(indeterminate, prevIndeterminate) {
+        _indeterminateChanged(indeterminate) {
           if (indeterminate) {
             this.setAttribute('aria-checked', 'mixed');
-          }
-
-          if (prevIndeterminate === undefined && indeterminate === false) {
-            return;
-          }
-
-          if (this.checked) {
-            this.checked = false;
-          }
-
-          if (!indeterminate) {
-            this.checked = true;
+          } else {
+            this.setAttribute('aria-checked', this.checked);
           }
         }
 


### PR DESCRIPTION
Connects to #42 
Fixes #48

Reverting to native checkbox behavior

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-checkbox/47)
<!-- Reviewable:end -->
