### PR TITLE
FFS demos

### DIFF
--- a/demo/checkbox-a11y-demos.html
+++ b/demo/checkbox-a11y-demos.html
@@ -1,0 +1,29 @@
+<dom-module id="checkbox-accessibility-demos">
+  <template>
+    <style include="vaadin-component-demo-shared-styles">
+       :host {
+        display: block;
+      }
+    </style>
+
+    <h3>Accessible Checkbox</h3>
+    <p>You can wrap any content inside the <code>&lt;vaadin-checkbox&gt;</code> element – you don’t need to wrap it with an extra <code>&lt;label&gt;</code> element.</p>
+    <p>The content acts as the accessible label for the checkbox. The user can click on the label to toggle the checkbox, and screen readers will announce the text content when the checkbox is focused.</p>
+    <p>You can focus the checkbox using the keyboard and activate it with the <kbd>Space</kbd> key. Notice how the visual active style is also triggered, giving keyboard users clear visual feedback that the checkbox was toggled.</p>
+    <vaadin-demo-snippet id='button-a11y-demos-accessible-label'>
+      <template preserve-content>
+        <vaadin-checkbox>Option</vaadin-checkbox>
+      </template>
+    </vaadin-demo-snippet>
+
+  </div>
+  </template>
+  <script>
+    class CheckboxA11yDemos extends DemoReadyEventEmitter(CheckboxDemo(Polymer.Element)) {
+      static get is() {
+        return 'checkbox-accessibility-demos';
+      }
+    }
+    customElements.define(CheckboxA11yDemos.is, CheckboxA11yDemos);
+  </script>
+</dom-module>

--- a/demo/checkbox-basic-demos.html
+++ b/demo/checkbox-basic-demos.html
@@ -1,58 +1,45 @@
 <dom-module id="checkbox-basic-demos">
   <template>
-    <style>
+    <style include="vaadin-component-demo-shared-styles">
        :host {
         display: block;
       }
 
     </style>
 
+    <h3>Basic Checkbox</h3>
+    <vaadin-demo-snippet id="checkbox-basic-demos-default-checkbox">
+      <template preserve-content>
+        <vaadin-checkbox checked>Option label</vaadin-checkbox>
+      </template>
+    </vaadin-demo-snippet>
 
-    <h3>Default Checkbox</h3>
-    <vaadin-demo-snippet id='checkbox-basic-demos-default-checkbox'>
+    <h3>Custom Label</h3>
+    <vaadin-demo-snippet id="checkbox-basic-demos-multiline-checkbox">
       <template preserve-content>
         <vaadin-checkbox checked>
-          Make my profile visible
+          <iron-icon icon="valo:bell" style="vertical-align: top;"></iron-icon>
+          Notifications
+          <br>
+          <small>Enable desktop notifications</small>
         </vaadin-checkbox>
       </template>
     </vaadin-demo-snippet>
 
-
-    <h3>Checkbox with Custom Accessible Label</h3>
-    <vaadin-demo-snippet id='checkbox-basic-demos-checkbox-with-custom-accessible-label'>
+    <h3>Disabled</h3>
+    <vaadin-demo-snippet id="checkbox-basic-demos-disabled-checkbox">
       <template preserve-content>
-        <vaadin-checkbox aria-label="Click Me">Accessible</vaadin-checkbox>
+        <vaadin-checkbox disabled checked>
+          Option two<br>
+          <small>Description for this option</small>
+        </vaadin-checkbox>
+
+        <vaadin-checkbox disabled>Option two</vaadin-checkbox>
+
+        <vaadin-checkbox disabled indeterminate>Indeterminate</vaadin-checkbox>
       </template>
     </vaadin-demo-snippet>
 
-
-    <h3>Checkboxes with Custom Tabindex</h3>
-    <vaadin-demo-snippet id='checkbox-basic-demos-checkboxes-with-custom-tabindex'>
-      <template preserve-content>
-        <div><vaadin-checkbox tabindex="1">1</vaadin-checkbox></div>
-        <div><vaadin-checkbox tabindex="3">3</vaadin-checkbox></div>
-        <div><vaadin-checkbox tabindex="2">2</vaadin-checkbox></div>
-      </template>
-    </vaadin-demo-snippet>
-
-
-    <h3>Disabled Checkbox</h3>
-    <vaadin-demo-snippet id='checkbox-basic-demos-disabled-checkbox'>
-      <template preserve-content>
-        <vaadin-checkbox disabled>Disabled</vaadin-checkbox>
-      </template>
-    </vaadin-demo-snippet>
-
-    <h3>
-      <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#Indeterminate_state_checkboxes" target="_blank" rel="noopener">Indeterminate Checkbox</a>
-      (when checkbox is neither checked nor unchecked)
-    </h3>
-    <vaadin-demo-snippet id='checkbox-basic-demos-disabled-checkbox'>
-      <template preserve-content>
-        <vaadin-checkbox indeterminate>Indeterminate</vaadin-checkbox>
-      </template>
-    </vaadin-demo-snippet>
-  </div>
   </template>
   <script>
     class CheckboxBasicDemos extends DemoReadyEventEmitter(CheckboxDemo(Polymer.Element)) {

--- a/demo/checkbox-indeterminate-demos.html
+++ b/demo/checkbox-indeterminate-demos.html
@@ -1,0 +1,57 @@
+<dom-module id="checkbox-indeterminate-demos">
+  <template>
+    <style include="vaadin-component-demo-shared-styles">
+       :host {
+        display: block;
+      }
+    </style>
+
+    <h3>Indeterminate Checkbox</h3>
+    <p>An <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#Indeterminate_state_checkboxes" target="_blank" rel="noopener">indeterminate checkbox</a> is neither checked nor unchecked. A typical use case is a “Select All” checkbox indicating that some, but not all, items are selected.</p>
+    <vaadin-demo-snippet id="checkbox-indeterminate-demo">
+      <template preserve-content>
+        <x-indeterminate-checkbox-example></x-indeterminate-checkbox-example>
+        <dom-module id="x-indeterminate-checkbox-example">
+          <template preserve-content>
+            <vaadin-checkbox indeterminate="[[_isIndeterminate(optionOne, optionTwo)]]" checked="[[_isAllSelected(optionOne, optionTwo)]]" on-checked-changed="_selectAll">Select All</vaadin-checkbox>
+            <vaadin-checkbox checked="{{optionOne}}">Option one</vaadin-checkbox>
+            <vaadin-checkbox checked="{{optionTwo}}">Option two</vaadin-checkbox>
+          </template>
+          <script>
+            window.addDemoReadyListener('#checkbox-indeterminate-demo', function(document) {
+              class XIndeterminateCheckboxExample extends Polymer.Element {
+                static get is() {
+                  return 'x-indeterminate-checkbox-example';
+                }
+                ready() {
+                  super.ready();
+                  this.optionOne = true;
+                }
+                _isAllSelected(optionOne, optionTwo) {
+                  return (optionOne === true) && (optionOne == optionTwo);
+                }
+                _isIndeterminate(optionOne, optionTwo) {
+                  return optionOne != optionTwo;
+                }
+                _selectAll(e) {
+                  this.optionOne = e.detail.value;
+                  this.optionTwo = e.detail.value;
+                }
+              }
+              window.customElements.define(XIndeterminateCheckboxExample.is, XIndeterminateCheckboxExample);
+            });
+          </script>
+        </dom-module>
+      </template>
+    </vaadin-demo-snippet>
+
+  </template>
+  <script>
+    class CheckboxIndeterminateDemos extends DemoReadyEventEmitter(CheckboxDemo(Polymer.Element)) {
+      static get is() {
+        return 'checkbox-indeterminate-demos';
+      }
+    }
+    customElements.define(CheckboxIndeterminateDemos.is, CheckboxIndeterminateDemos);
+  </script>
+</dom-module>

--- a/demo/demos.json
+++ b/demo/demos.json
@@ -2,11 +2,33 @@
   "name": "Vaadin Checkbox",
   "pages": [
   {
-    "name": "Basic Examples",
+    "name": "Basics",
     "url": "checkbox-basic-demos",
     "src": "checkbox-basic-demos.html",
     "meta": {
-      "title": "vaadin-checkbox Basic Examples",
+      "title": "Vaadin Checkbox Basics",
+      "description": "",
+      "image": ""
+     }
+  }
+  ,
+  {
+    "name": "Indeterminate State",
+    "url": "checkbox-indeterminate-demos",
+    "src": "checkbox-indeterminate-demos.html",
+    "meta": {
+      "title": "Vaadin Checkbox Indeterminate State",
+      "description": "",
+      "image": ""
+     }
+  }
+  ,
+  {
+    "name": "Accessibility",
+    "url": "checkbox-accessibility-demos",
+    "src": "checkbox-a11y-demos.html",
+    "meta": {
+      "title": "Vaadin Checkbox Accessibility",
       "description": "",
       "image": ""
      }

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,14 +3,12 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-  <title>vaadin-checkbox Examples</title>
+  <title>Vaadin Checkbox Examples</title>
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
-  <style>
-    body {
-      font-family: sans-serif;
-    }
-  </style>
+  <custom-style>
+    <style include="vaadin-component-demo-shared-styles"></style>
+  </custom-style>
 </head>
 
 <body>
@@ -21,8 +19,9 @@
 
   <link rel="import" href="checkbox-demo.html">
 
-  <link rel="import" href="../../paper-styles/default-theme.html">
   <link rel="import" href="../vaadin-checkbox.html">
+  
+  <link rel="import" href="../../vaadin-valo-theme/icons.html">
 
   <vaadin-component-demo config-src="demos.json"></vaadin-component-demo>
 </body>


### PR DESCRIPTION
- Depends on https://github.com/vaadin/vaadin-demo-helpers/pull/13

- Remove superfluous tabindex example

- Add an example for customized/multi-line labels

- Improve indeterminate example to be an actual use case

- Move indeterminate and accessibility examples to a separate pages

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-checkbox/54)
<!-- Reviewable:end -->
