### PR TITLE
Add toggleChecked to handle programmatically invoked click

### DIFF
--- a/src/vaadin-checkbox.html
+++ b/src/vaadin-checkbox.html
@@ -253,6 +253,8 @@ This program is available under Apache License Version 2.0, available at https:/
                * See issue here: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7344418/
                */
               this.indeterminate = false;
+              e.preventDefault();
+              this._toggleChecked();
             }
           }
         }

--- a/test/vaadin-checkbox_test.html
+++ b/test/vaadin-checkbox_test.html
@@ -210,6 +210,27 @@
         expect(vaadinCheckbox.getAttribute('aria-checked')).to.be.eql('false');
       });
 
+      it('should be checked after click when initially checked is false and indeterminate is true', () => {
+        vaadinCheckbox.checked = false;
+        vaadinCheckbox.indeterminate = true;
+
+        vaadinCheckbox.click();
+
+        expect(vaadinCheckbox.checked).to.be.true;
+        expect(vaadinCheckbox.indeterminate).to.be.false;
+        expect(vaadinCheckbox.getAttribute('aria-checked')).to.be.eql('true');
+      });
+
+      it('should not be checked after click when initially checked is true and indeterminate is true', () => {
+        vaadinCheckbox.checked = true;
+        vaadinCheckbox.indeterminate = true;
+
+        vaadinCheckbox.click();
+
+        expect(vaadinCheckbox.checked).to.be.false;
+        expect(vaadinCheckbox.indeterminate).to.be.false;
+        expect(vaadinCheckbox.getAttribute('aria-checked')).to.be.eql('false');
+      });
     });
 
     describe('iron-form-checkbox', () => {


### PR DESCRIPTION
Fixes #70 
Add `toggleChecked` to handle programmatically invoked click

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-checkbox/78)
<!-- Reviewable:end -->
