### PR TITLE
Use bare module specifiers in the P3 conversion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
       npm install -g yarn magi-cli polymer-cli@next &&
       (cd .. && git clone --depth 1 -b vaadin-components git://github.com/web-padawan/polymer-modulizer.git && cd polymer-modulizer && npm link) &&
       rm -rf node_modules &&
-      magi p3-convert --out . &&
+      magi p3-convert --out . --import-style=name &&
       yarn install --flat &&
       if [[ "$TRAVIS_EVENT_TYPE" = "pull_request" ]]; then
         xvfb-run -s '-screen 0 1024x768x24' polymer test --module-resolution=node --npm -l chrome;

--- a/test/accessibility.html
+++ b/test/accessibility.html
@@ -4,9 +4,7 @@
   <meta charset="UTF-8">
   <title>vaadin-checkbox tests</title>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../iron-test-helpers/mock-interactions.js"></script>
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-  <link rel="import" href="../../polymer/polymer.html">
   <link rel="import" href="../vaadin-checkbox.html">
 </head>
 

--- a/test/accessibility.html
+++ b/test/accessibility.html
@@ -5,6 +5,7 @@
   <title>vaadin-checkbox tests</title>
   <script src="../../web-component-tester/browser.js"></script>
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../vaadin-checkbox.html">
 </head>
 

--- a/test/vaadin-checkbox_test.html
+++ b/test/vaadin-checkbox_test.html
@@ -6,6 +6,7 @@
   <script src="../../web-component-tester/browser.js"></script>
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../../iron-test-helpers/mock-interactions.html">
+  <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../../polymer/lib/utils/flattened-nodes-observer.html">
   <link rel="import" href="../../iron-form/iron-form.html">
   <link rel="import" href="../vaadin-checkbox.html">

--- a/test/vaadin-checkbox_test.html
+++ b/test/vaadin-checkbox_test.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <title>vaadin-checkbox tests</title>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../iron-test-helpers/mock-interactions.js"></script>
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-  <link rel="import" href="../../polymer/polymer.html">
+  <link rel="import" href="../../iron-test-helpers/mock-interactions.html">
+  <link rel="import" href="../../polymer/lib/utils/flattened-nodes-observer.html">
   <link rel="import" href="../../iron-form/iron-form.html">
   <link rel="import" href="../vaadin-checkbox.html">
 </head>
@@ -73,7 +73,7 @@
       });
 
       it('should define checkbox label using light DOM', () => {
-        const children = Polymer.dom(label).getEffectiveChildNodes();
+        const children = Polymer.FlattenedNodesObserver.getFlattenedNodes(label);
         expect(children[1].textContent).to.be.equal('Vaadin ');
         expect(children[2].outerHTML).to.be.equal('<i>Checkbox</i>');
       });

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -18,7 +18,9 @@ module.exports = {
       'macOS 10.12/iphone@11.2',
       'macOS 10.12/ipad@11.2',
       'Windows 10/chrome@65',
-      'macOS 10.12/safari@11.0'
+      'macOS 10.12/safari@11.0',
+      'Windows 10/firefox@59',
+      'Windows 10/microsoftedge@16'
     ];
 
     var cronPlatforms = [


### PR DESCRIPTION
Connected to vaadin/components-team-tasks#332

Also did some cleanup to eliminate the single legacy `Polymer.dom` usage.

The `mock-interactions` change is needed because of the fact that `mock-interactions.js` still use the `Polymer.Base.async` and the HTML file imports the needed dependency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-checkbox/82)
<!-- Reviewable:end -->
