### PR TITLE
Add exception on click handeler for link

### DIFF
--- a/src/vaadin-checkbox.html
+++ b/src/vaadin-checkbox.html
@@ -241,7 +241,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         _handleClick(e) {
-          if (!this.disabled) {
+          if (!this.disabled && !(e.target.matches || e.target.matchesSelector).call(e.target, 'a')) {
             if (!this.indeterminate) {
               if (e.composedPath()[0] !== this._nativeCheckbox) {
                 e.preventDefault();


### PR DESCRIPTION
Prevents checking/unchecking the checkbox when clicking on a `<a href>` node inside the label and prevents the e.preventDefault making the link actually do something.

Scenario: checkbox for Terms and Conditions where the label contains a link to the actual terms and conditions.

Using `e.target.matches || e.target.matchesSelector` that should be compatible with all mayor browsers including IE11.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-checkbox/86)
<!-- Reviewable:end -->
