### PR TITLE
Prevent toggling on links click inside a label

### DIFF
--- a/demo/checkbox-basic-demos.html
+++ b/demo/checkbox-basic-demos.html
@@ -9,7 +9,7 @@
     <h3>Basic Checkbox</h3>
     <vaadin-demo-snippet id="checkbox-basic-demos-default-checkbox">
       <template preserve-content>
-        <vaadin-checkbox checked>Option label</vaadin-checkbox>
+        <vaadin-checkbox checked>I agree with <a href>Terms & Conditions</a></vaadin-checkbox>
       </template>
     </vaadin-demo-snippet>
 

--- a/src/vaadin-checkbox.html
+++ b/src/vaadin-checkbox.html
@@ -207,7 +207,7 @@ This program is available under Apache License Version 2.0, available at https:/
         _addActiveListeners() {
           // DOWN
           this._addEventListenerToNode(this, 'down', (e) => {
-            if (this._interactionsAllowed(e)) {
+            if (this.__interactionsAllowed(e)) {
               this.setAttribute('active', '');
             }
           });
@@ -217,7 +217,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
           // KEYDOWN
           this.addEventListener('keydown', e => {
-            if (this._interactionsAllowed(e) && e.keyCode === 32) {
+            if (this.__interactionsAllowed(e) && e.keyCode === 32) {
               e.preventDefault();
               this.setAttribute('active', '');
             }
@@ -225,7 +225,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
           // KEYUP
           this.addEventListener('keyup', e => {
-            if (this._interactionsAllowed(e) && e.keyCode === 32) {
+            if (this.__interactionsAllowed(e) && e.keyCode === 32) {
               e.preventDefault();
               this._toggleChecked();
               this.removeAttribute('active');
@@ -241,7 +241,11 @@ This program is available under Apache License Version 2.0, available at https:/
           return this.shadowRoot.querySelector('label');
         }
 
-        _interactionsAllowed(e) {
+        /**
+         * True if users' interactions (mouse or keyboard)
+         * should toggle the checkbox
+         */
+        __interactionsAllowed(e) {
           if (this.disabled) {
             return false;
           }
@@ -255,7 +259,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         _handleClick(e) {
-          if (this._interactionsAllowed(e)) {
+          if (this.__interactionsAllowed(e)) {
             if (!this.indeterminate) {
               if (e.composedPath()[0] !== this._nativeCheckbox) {
                 e.preventDefault();

--- a/src/vaadin-checkbox.html
+++ b/src/vaadin-checkbox.html
@@ -207,7 +207,7 @@ This program is available under Apache License Version 2.0, available at https:/
         _addActiveListeners() {
           // DOWN
           this._addEventListenerToNode(this, 'down', (e) => {
-            if (!this.disabled) {
+            if (this._interactionsAllowed(e)) {
               this.setAttribute('active', '');
             }
           });
@@ -217,7 +217,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
           // KEYDOWN
           this.addEventListener('keydown', e => {
-            if (!this.disabled && e.keyCode === 32) {
+            if (this._interactionsAllowed(e) && e.keyCode === 32) {
               e.preventDefault();
               this.setAttribute('active', '');
             }
@@ -225,7 +225,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
           // KEYUP
           this.addEventListener('keyup', e => {
-            if (!this.disabled && e.keyCode === 32) {
+            if (this._interactionsAllowed(e) && e.keyCode === 32) {
               e.preventDefault();
               this._toggleChecked();
               this.removeAttribute('active');
@@ -241,8 +241,21 @@ This program is available under Apache License Version 2.0, available at https:/
           return this.shadowRoot.querySelector('label');
         }
 
+        _interactionsAllowed(e) {
+          if (this.disabled) {
+            return false;
+          }
+
+          // https://github.com/vaadin/vaadin-checkbox/issues/63
+          if (e.target.localName === 'a') {
+            return false;
+          }
+
+          return true;
+        }
+
         _handleClick(e) {
-          if (!this.disabled) {
+          if (this._interactionsAllowed(e)) {
             if (!this.indeterminate) {
               if (e.composedPath()[0] !== this._nativeCheckbox) {
                 e.preventDefault();

--- a/test/vaadin-checkbox_test.html
+++ b/test/vaadin-checkbox_test.html
@@ -43,7 +43,7 @@
 
   <test-fixture id="default">
     <template>
-      <vaadin-checkbox name="test-checkbox">Vaadin <i>Checkbox</i></vaadin-checkbox>
+      <vaadin-checkbox name="test-checkbox">Vaadin <i>Checkbox</i> with <a href="#">Terms &amp; Conditions</a></vaadin-checkbox>
     </template>
   </test-fixture>
 
@@ -106,6 +106,13 @@
 
         vaadinCheckbox.click();
 
+        expect(vaadinCheckbox.checked).to.be.false;
+      });
+
+      it('should not toggle on link inside host click', () => {
+        const link = Polymer.dom(label).getEffectiveChildNodes()[4];
+        expect(link.outerHTML).to.be.equal('<a href="#">Terms &amp; Conditions</a>');
+        link.click();
         expect(vaadinCheckbox.checked).to.be.false;
       });
 


### PR DESCRIPTION
Fixes #63 

> There are two hard problems in Computer Science: cache invalidation and naming things.

I would appreciate if anyone has the better name for the `_interactionsAllowed` method, I don't like the current name, but I can't come up with the better one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-checkbox/93)
<!-- Reviewable:end -->
