### PR TITLE
Set value to the new array instance every time

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,10 +24,10 @@
   ],
   "dependencies": {
     "polymer": "^2.0.0",
-    "vaadin-control-state-mixin": "vaadin/vaadin-control-state-mixin#^2.1.0-alpha2",
+    "vaadin-control-state-mixin": "vaadin/vaadin-control-state-mixin#^2.1.1",
     "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.2.0",
-    "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.1.0-alpha3",
-    "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.1.0-alpha2",
+    "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.1.0-beta1",
+    "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.1.0-beta1",
     "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^1.1.0"
   },
   "devDependencies": {
@@ -36,8 +36,8 @@
     "iron-test-helpers": "^2.0.0",
     "webcomponentsjs": "^1.0.1",
     "web-component-tester": "^6.1.5",
-    "vaadin-demo-helpers": "vaadin/vaadin-demo-helpers#^2.0.0-alpha2",
+    "vaadin-demo-helpers": "vaadin/vaadin-demo-helpers#^2.0.0",
     "iron-form": "^2.0.1",
-    "vaadin-button": "^2.0.1"
+    "vaadin-button": "vaadin/vaadin-button#^2.1.0-beta1"
   }
 }

--- a/src/vaadin-checkbox-group.html
+++ b/src/vaadin-checkbox-group.html
@@ -108,8 +108,8 @@ This program is available under Apache License Version 2.0, available at https:/
             },
 
             /**
-            * String used for the label element.
-            */
+             * String used for the label element.
+             */
             label: {
               type: String,
               value: '',
@@ -118,6 +118,9 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * Value of the checkbox group.
+             * Note: toggling the checkboxes modifies the value by creating new
+             * array each time, to override Polymer dirty-checking for arrays.
+             * You can still use Polymer array mutation methods to update the value.
              */
             value: {
               type: Array,
@@ -156,7 +159,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         static get observers() {
           return [
-            '_valueChanged(value, value.splices)'
+            '_updateValue(value, value.splices)'
           ];
         }
 
@@ -170,9 +173,10 @@ This program is available under Apache License Version 2.0, available at https:/
             this._changeSelectedCheckbox(e.target);
           };
 
-          this._observer = new Polymer.FlattenedNodesObserver(this, (info) => {
+          this._observer = new Polymer.FlattenedNodesObserver(this, info => {
+            const addedCheckboxes = this._filterCheckboxes(info.addedNodes);
 
-            this._filterCheckboxes(info.addedNodes).forEach(checkbox => {
+            addedCheckboxes.forEach(checkbox => {
               checkbox.addEventListener('checked-changed', checkedChangedListener);
               if (this.disabled) {
                 checkbox.disabled = true;
@@ -189,9 +193,7 @@ This program is available under Apache License Version 2.0, available at https:/
               }
             });
 
-            const checkboxWithoutValue = this._filterCheckboxes(info.addedNodes).filter(checkbox => !checkbox
-              .getAttribute('value'));
-            if (checkboxWithoutValue.length) {
+            if (addedCheckboxes.some(checkbox => !checkbox.hasAttribute('value'))) {
               console.warn('Please add value attribute to all checkboxes in checkbox group');
             }
           });
@@ -230,12 +232,16 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         _addCheckboxToValue(value) {
-          this.push('value', value);
+          const update = this.value.slice(0);
+          update.push(value);
+          this.value = update;
         }
 
         _removeCheckboxFromValue(value) {
-          const index = this.value.indexOf(value);
-          this.splice('value', index, 1);
+          const update = this.value.slice(0);
+          const index = update.indexOf(value);
+          update.splice(index, 1);
+          this.value = update;
         }
 
         _changeSelectedCheckbox(checkbox) {
@@ -248,22 +254,22 @@ This program is available under Apache License Version 2.0, available at https:/
           } else {
             this._removeCheckboxFromValue(checkbox.value);
           }
-
         }
 
-        _valueChanged(newV, oldV) {
-          // setting initial value to empty string, skip validation
-          if (newV.length === 0 && oldV === undefined) {
+        _updateValue(value, splices) {
+          // setting initial value to empty array, skip validation
+          if (value.length === 0 && this._oldValue === undefined) {
             return;
           }
+          this._oldValue = value;
           // set a flag to avoid updating loop
           this._updatingValue = true;
           // reflect the value array to checkboxes
           this._checkboxes.forEach(checkbox => {
-            checkbox.checked = newV.indexOf(checkbox.value) > -1;
+            checkbox.checked = value.indexOf(checkbox.value) > -1;
           });
           this._updatingValue = false;
-    
+
           this.validate();
         }
 
@@ -278,7 +284,6 @@ This program is available under Apache License Version 2.0, available at https:/
         _getErrorMessageAriaHidden(invalid, errorMessage) {
           return (!errorMessage || !invalid).toString();
         }
-
       }
 
       customElements.define(CheckboxGroupElement.is, CheckboxGroupElement);

--- a/test/vaadin-checkbox-group_test.html
+++ b/test/vaadin-checkbox-group_test.html
@@ -25,16 +25,30 @@
 
 <test-fixture id="ironForm">
   <template>
-      <iron-form>
-        <form>
-          <vaadin-checkbox-group>
-            <vaadin-checkbox name="language" value="en">English</vaadin-checkbox>
-            <vaadin-checkbox name="language" value="fr">Français</vaadin-checkbox>
-            <vaadin-checkbox name="language" value="de">Deutsch</vaadin-checkbox>
-          </vaadin-checkbox-group>
-        </form>
-      </iron-form>
+    <iron-form>
+      <form>
+        <vaadin-checkbox-group>
+          <vaadin-checkbox name="language" value="en">English</vaadin-checkbox>
+          <vaadin-checkbox name="language" value="fr">Français</vaadin-checkbox>
+          <vaadin-checkbox name="language" value="de">Deutsch</vaadin-checkbox>
+        </vaadin-checkbox-group>
+      </form>
+    </iron-form>
   </template>
+</test-fixture>
+
+<test-fixture id="bind">
+  <template>
+    <dom-bind>
+      <template>
+        <vaadin-checkbox-group id="group" value="{{value}}">
+          <vaadin-checkbox value="a">Checkbox <b>a</b></vaadin-checkbox>
+          <vaadin-checkbox value="b">Checkbox <b>b</b></vaadin-checkbox>
+          <vaadin-checkbox value="c">Checkbox <b>c</b></vaadin-checkbox>
+        </vaadin-checkbox-group>
+      </template>
+    </template>
+  </dom-bind>
 </test-fixture>
 
 <script>
@@ -86,6 +100,25 @@
       vaadinCheckboxGroup.removeChild(checkbox);
       vaadinCheckboxGroup._observer.flush();
       expect(vaadinCheckboxGroup.value).to.not.include('1');
+    });
+
+    it('should create new array instance for checkbox group value when checkbox dynamically added', () => {
+      const value = vaadinCheckboxGroup.value;
+      const checkbox = document.createElement('vaadin-checkbox');
+      checkbox.value = 'new';
+      checkbox.checked = true;
+      vaadinCheckboxGroup.appendChild(checkbox);
+      vaadinCheckboxGroup._observer.flush();
+      expect(vaadinCheckboxGroup.value).to.not.equal(value);
+    });
+
+    it('should create new array instance for checkbox group value when checkbox dynamically removed', () => {
+      const value = vaadinCheckboxGroup.value;
+      const checkbox = vaadinCheckboxList[0];
+      checkbox.checked = true;
+      vaadinCheckboxGroup.removeChild(checkbox);
+      vaadinCheckboxGroup._observer.flush();
+      expect(vaadinCheckboxGroup.value).to.not.equal(value);
     });
 
     it('should not change checkbox group value if a removed checkbox is checked', () => {
@@ -229,5 +262,60 @@
 
   });
 
+  describe('vaadin-checkbox-group value array mutation methods', () => {
+
+    let bind, vaadinCheckboxGroup, vaadinCheckboxList;
+
+    beforeEach(() => {
+      bind = fixture('bind');
+      vaadinCheckboxGroup = bind.$.group;
+      vaadinCheckboxList = vaadinCheckboxGroup.querySelectorAll('vaadin-checkbox');
+      vaadinCheckboxGroup._observer.flush();
+    });
+
+    it('should notify the value changes from inside', () => {
+      expect(bind.value).to.be.array;
+      expect(bind.value.length).to.equal(0);
+
+      vaadinCheckboxList[0].checked = true;
+
+      expect(bind.value.length).to.equal(1);
+      expect(bind.value[0]).to.equal('a');
+    });
+
+    it('should update checkboxes when a checkbox value is updated using push', () => {
+      bind.push('value', 'a');
+      expect(vaadinCheckboxList[0].checked).to.be.true;
+    });
+
+    it('should update checkboxes when a checkbox value is updated using pop', () => {
+      bind.value = ['a', 'b'];
+      bind.pop('value');
+      expect(vaadinCheckboxList[0].checked).to.be.true;
+      expect(vaadinCheckboxList[1].checked).to.be.false;
+    });
+
+    it('should update checkboxes when a checkbox value is updated using push', () => {
+      bind.value = ['b'];
+      bind.unshift('value', 'a');
+      expect(vaadinCheckboxList[1].checked).to.be.true;
+      expect(vaadinCheckboxList[0].checked).to.be.true;
+    });
+
+    it('should update checkboxes when a checkbox value is updated using unshift', () => {
+      bind.value = ['a', 'b'];
+      bind.shift('value');
+      expect(vaadinCheckboxList[0].checked).to.be.false;
+      expect(vaadinCheckboxList[1].checked).to.be.true;
+    });
+
+    it('should update checkboxes when a checkbox value is updated using splice', () => {
+      bind.value = ['a', 'b'];
+      bind.splice('value', 1, 1, 'c');
+      expect(vaadinCheckboxList[0].checked).to.be.true;
+      expect(vaadinCheckboxList[1].checked).to.be.false;
+      expect(vaadinCheckboxList[2].checked).to.be.true;
+    });
+  });
 </script>
 </body>


### PR DESCRIPTION
Fixes #109 

Note that we need 2 observers now:
- one for "splices" - to cover value change from outside, using array mutation methods (see new tests)
- second one for value change from the inside, as the multi-property observer is no longer reliable in the matter of "initial state" check for validation (old value can be only available in single-property observer, so the `undefined` check is what matters)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-checkbox/110)
<!-- Reviewable:end -->
