### PR TITLE
Fix empty slot check

### DIFF
--- a/src/vaadin-checkbox.html
+++ b/src/vaadin-checkbox.html
@@ -14,7 +14,7 @@ This program is available under Apache License Version 2.0, available at https:/
   <template>
     <style>
       :host {
-        display: inline-flex;
+        display: inline-block;
       }
 
       label {

--- a/src/vaadin-checkbox.html
+++ b/src/vaadin-checkbox.html
@@ -197,15 +197,19 @@ This program is available under Apache License Version 2.0, available at https:/
         _updateLabelAttribute() {
           const label = this.shadowRoot.querySelector('[part~="label"]');
           const assignedNodes = label.firstElementChild.assignedNodes();
-          // The label is empty if there is no slotted content or only one empty text node
-          if (assignedNodes.length === 0 ||
-              (assignedNodes.length == 1
-                && assignedNodes[0].nodeType == 3
-                && assignedNodes[0].textContent.trim().length === 0)) {
+          if (this._isAssignedNodesEmpty(assignedNodes)) {
             label.setAttribute('empty', '');
           } else {
             label.removeAttribute('empty');
           }
+        }
+
+        _isAssignedNodesEmpty(nodes) {
+          // The assigned nodes considered to be empty if there is no slotted content or only one empty text node
+          return nodes.length === 0 ||
+                (nodes.length == 1
+                && nodes[0].nodeType == Node.TEXT_NODE
+                && nodes[0].textContent.trim() === '');
         }
 
         _checkedChanged(checked) {

--- a/src/vaadin-checkbox.html
+++ b/src/vaadin-checkbox.html
@@ -14,7 +14,7 @@ This program is available under Apache License Version 2.0, available at https:/
   <template>
     <style>
       :host {
-        display: inline-block;
+        display: inline-flex;
       }
 
       label {
@@ -196,7 +196,12 @@ This program is available under Apache License Version 2.0, available at https:/
 
         _updateLabelAttribute() {
           const label = this.shadowRoot.querySelector('[part~="label"]');
-          if (label.firstElementChild.assignedNodes().length === 0) {
+          const assignedNodes = label.firstElementChild.assignedNodes();
+          // The label is empty if there is no slotted content or only one empty text node
+          if (assignedNodes.length === 0 ||
+              (assignedNodes.length == 1
+                && assignedNodes[0].nodeType == 3
+                && assignedNodes[0].textContent.trim().length === 0)) {
             label.setAttribute('empty', '');
           } else {
             label.removeAttribute('empty');

--- a/test/vaadin-checkbox_test.html
+++ b/test/vaadin-checkbox_test.html
@@ -278,6 +278,17 @@
         expect(label.hasAttribute('empty')).to.be.true;
       });
 
+      it('should set empty attribute on part label when there is only one empty text node added', () => {
+        const textNode = document.createTextNode(' ');
+        vaadinCheckbox.appendChild(textNode);
+
+        // Workaround for not using timeouts
+        const evt = new CustomEvent('slotchange');
+        vaadinCheckbox.shadowRoot.querySelector('[part="label"]').querySelector('slot').dispatchEvent(evt);
+
+        expect(label.hasAttribute('empty')).to.be.true;
+      });
+
       it('should remove empty attribute from part label when the label is added', () => {
         const paragraph = document.createElement('p');
         paragraph.textContent = 'Added label';


### PR DESCRIPTION
Fixes #130 

Consider the label empty also if there is only one empty text node inside the `<vaadin-checkbox>` tag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-checkbox/129)
<!-- Reviewable:end -->
