### PR TITLE
Remove checkboxgroup role

### DIFF
--- a/src/vaadin-checkbox-group.html
+++ b/src/vaadin-checkbox-group.html
@@ -167,8 +167,6 @@ This program is available under Apache License Version 2.0, available at https:/
         ready() {
           super.ready();
 
-          this.setAttribute('role', 'checkboxgroup');
-
           this.addEventListener('focusout', e => {
             // validate when stepping out of the checkbox group
             if (!this._checkboxes.some(checkbox => e.relatedTarget === checkbox || checkbox.shadowRoot.contains(e.relatedTarget))) {

--- a/test/vaadin-checkbox-group_test.html
+++ b/test/vaadin-checkbox-group_test.html
@@ -62,8 +62,8 @@
       vaadinCheckboxGroup._observer.flush();
     });
 
-    it('sets role properly', () => {
-      expect(vaadinCheckboxGroup.getAttribute('role')).to.eq('checkboxgroup');
+    it('does not set a role', () => {
+      expect(vaadinCheckboxGroup.getAttribute('role')).to.eq(null);
     });
 
     it('changes aria-disabled on disabled change', () => {


### PR DESCRIPTION
`checkboxgroup` doesn't seem to be a real role. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#Widget_roles

Also fails to Lighthouse A11Y tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-checkbox/131)
<!-- Reviewable:end -->
