### PR TITLE
Use --lumo-border-radius-s

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "polymer": "^2.0.0",
     "vaadin-control-state-mixin": "vaadin/vaadin-control-state-mixin#^2.1.1",
     "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.2.1",
-    "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.2.0",
+    "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.4.1",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.2.0",
     "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.0.0"
   },

--- a/theme/lumo/vaadin-checkbox-styles.html
+++ b/theme/lumo/vaadin-checkbox-styles.html
@@ -36,7 +36,7 @@
         height: calc(1em + 2px);
         margin: 0.1875em;
         position: relative;
-        border-radius: var(--lumo-border-radius);
+        border-radius: var(--lumo-border-radius-s);
         background-color: var(--lumo-contrast-20pct);
         transition: transform 0.2s cubic-bezier(.12, .32, .54, 2), background-color 0.15s;
         pointer-events: none;


### PR DESCRIPTION
Prevent the checkbox from turning into a full circle, which could easily happen when there’s only one border-radius property to control.

Connected to vaadin/vaadin-lumo-styles#63
### Before merging, update bower.json to depend on the version of vaadin-lumo-styles where the new property is released

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-checkbox/140)
<!-- Reviewable:end -->
