### PR TITLE
Fix checkbox-group issues with dynamically added checkboxes

### DIFF
--- a/src/vaadin-checkbox-group.html
+++ b/src/vaadin-checkbox-group.html
@@ -234,17 +234,12 @@ This program is available under Apache License Version 2.0, available at https:/
 
         _addCheckboxToValue(value) {
           if (this.value.indexOf(value) === -1) {
-            const update = this.value.slice(0);
-            update.push(value);
-            this.value = update;
+            this.value = this.value.concat(value);
           }
         }
 
         _removeCheckboxFromValue(value) {
-          const update = this.value.slice(0);
-          const index = update.indexOf(value);
-          update.splice(index, 1);
-          this.value = update;
+          this.value = this.value.filter(v => v !== value);
         }
 
         _changeSelectedCheckbox(checkbox) {

--- a/src/vaadin-checkbox-group.html
+++ b/src/vaadin-checkbox-group.html
@@ -188,6 +188,8 @@ This program is available under Apache License Version 2.0, available at https:/
               }
               if (checkbox.checked) {
                 this._addCheckboxToValue(checkbox.value);
+              } else if (this.value.indexOf(checkbox.value) > -1) {
+                checkbox.checked = true;
               }
             });
 

--- a/src/vaadin-checkbox-group.html
+++ b/src/vaadin-checkbox-group.html
@@ -231,9 +231,11 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         _addCheckboxToValue(value) {
-          const update = this.value.slice(0);
-          update.push(value);
-          this.value = update;
+          if (this.value.indexOf(value) === -1) {
+            const update = this.value.slice(0);
+            update.push(value);
+            this.value = update;
+          }
         }
 
         _removeCheckboxFromValue(value) {

--- a/test/vaadin-checkbox-group_test.html
+++ b/test/vaadin-checkbox-group_test.html
@@ -94,6 +94,16 @@
       expect(vaadinCheckboxGroup.value).to.include('new');
     });
 
+    it('should not add duplicate values when added checked checkbox already included in value', () => {
+      const checkbox = document.createElement('vaadin-checkbox');
+      checkbox.value = 'new';
+      checkbox.checked = true;
+      vaadinCheckboxGroup.value = ['new'];
+      vaadinCheckboxGroup.appendChild(checkbox);
+      vaadinCheckboxGroup._observer.flush();
+      expect(vaadinCheckboxGroup.value).to.eql(['new']);
+    });
+
     it('should remove checked checkbox value from checkbox group value, when checkbox is dynamically removed', () => {
       const checkbox = vaadinCheckboxList[0];
       checkbox.checked = true;

--- a/test/vaadin-checkbox-group_test.html
+++ b/test/vaadin-checkbox-group_test.html
@@ -104,6 +104,16 @@
       expect(vaadinCheckboxGroup.value).to.eql(['new']);
     });
 
+    it('should check dynamically added checkbox if included in value', () => {
+      const checkbox = document.createElement('vaadin-checkbox');
+      checkbox.value = 'new';
+      vaadinCheckboxGroup.value = ['new'];
+      vaadinCheckboxGroup.appendChild(checkbox);
+      vaadinCheckboxGroup._observer.flush();
+      expect(vaadinCheckboxGroup.value).to.eql(['new']);
+      expect(checkbox.checked).to.be.true;
+    });
+
     it('should remove checked checkbox value from checkbox group value, when checkbox is dynamically removed', () => {
       const checkbox = vaadinCheckboxList[0];
       checkbox.checked = true;

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -33,17 +33,17 @@ module.exports = {
 
   registerHooks: function(context) {
     const saucelabsPlatformsMobile = [
-      'iOS Simulator/iphone@11.3',
-      'iOS Simulator/iphone@9.3'
+      'iOS Simulator/iphone@12.2',
+      'iOS Simulator/iphone@10.3'
     ];
 
     const saucelabsPlatformsMicrosoft = [
-      'Windows 10/microsoftedge@17',
+      'Windows 10/microsoftedge@18',
       'Windows 10/internet explorer@11'
     ];
 
     const saucelabsPlatformsDesktop = [
-      'macOS 10.13/safari@11.1'
+      'macOS 10.13/safari@latest'
     ];
 
     const saucelabsPlatforms = [
@@ -56,10 +56,10 @@ module.exports = {
       {
         deviceName: 'Android GoogleAPI Emulator',
         platformName: 'Android',
-        platformVersion: '7.1',
+        platformVersion: '8.1',
         browserName: 'chrome'
       },
-      'iOS Simulator/ipad@11.3',
+      'iOS Simulator/ipad@12.2',
       'iOS Simulator/iphone@10.3',
       'Windows 10/chrome@latest',
       'Windows 10/firefox@latest'


### PR DESCRIPTION
Two fixes in separate commits (so don't squash).

These are mostly relevant for the Flow component, as Flow always creates the child checkboxes dynamically.
vaadin/vaadin-checkbox-flow#83
vaadin/vaadin-checkbox-flow#89

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-checkbox/147)
<!-- Reviewable:end -->
