### PR TITLE
feat: bump element-mixin to 2.3.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.2.1",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.2.0",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.2.0",
-    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.0.0"
+    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.3.0"
   },
   "devDependencies": {
     "iron-component-page": "^3.0.0",


### PR DESCRIPTION
There is already a commit merged to `master` that depends on `DirMixin`.
We should bump version and make it explicit that it needs a new minor.