### PR TITLE
fix: prevent incorrect console warning

### DIFF
--- a/src/vaadin-checkbox-group.html
+++ b/src/vaadin-checkbox-group.html
@@ -210,7 +210,11 @@ This program is available under Apache License Version 2.0, available at https:/
               }
             });
 
-            if (addedCheckboxes.some(checkbox => !checkbox.hasAttribute('value'))) {
+            const hasValue = checkbox => {
+              const {value} = checkbox;
+              return checkbox.hasAttribute('value') || value && value !== 'on';
+            };
+            if (!addedCheckboxes.every(hasValue)) {
               console.warn('Please add value attribute to all checkboxes in checkbox group');
             }
           });

--- a/test/vaadin-checkbox-group_test.html
+++ b/test/vaadin-checkbox-group_test.html
@@ -280,6 +280,38 @@
 
       expect(spy).to.not.be.called;
     });
+
+    it('should warn when adding checkbox without value', () => {
+      sinon.stub(console, 'warn');
+
+      const checkbox = document.createElement('vaadin-checkbox');
+      vaadinCheckboxGroup.appendChild(checkbox);
+      vaadinCheckboxGroup._observer.flush();
+      expect(console.warn.callCount).to.equal(1);
+      console.warn.restore();
+    });
+
+    it('should not warn when adding checkbox with value attribute', () => {
+      sinon.stub(console, 'warn');
+
+      const checkbox = document.createElement('vaadin-checkbox');
+      checkbox.setAttribute('value', 'something');
+      vaadinCheckboxGroup.appendChild(checkbox);
+      vaadinCheckboxGroup._observer.flush();
+      expect(console.warn.callCount).to.equal(0);
+      console.warn.restore();
+    });
+
+    it('should not warn when adding checkbox with value property', () => {
+      sinon.stub(console, 'warn');
+
+      const checkbox = document.createElement('vaadin-checkbox');
+      checkbox.value = 'something';
+      vaadinCheckboxGroup.appendChild(checkbox);
+      vaadinCheckboxGroup._observer.flush();
+      expect(console.warn.callCount).to.equal(0);
+      console.warn.restore();
+    });
   });
 
   describe('vaadin-checkbox-group validation', () => {


### PR DESCRIPTION
Fixes #161. This is a PR for `2.2` branch, has to be cherry-picked to master later on.