### PR TITLE
fix: set aria-checked properly when checked is null [2.2] (#164)

### DIFF
--- a/src/vaadin-checkbox.html
+++ b/src/vaadin-checkbox.html
@@ -221,7 +221,7 @@ This program is available under Apache License Version 2.0, available at https:/
           if (this.indeterminate) {
             this.setAttribute('aria-checked', 'mixed');
           } else {
-            this.setAttribute('aria-checked', checked);
+            this.setAttribute('aria-checked', Boolean(checked));
           }
         }
 

--- a/test/accessibility.html
+++ b/test/accessibility.html
@@ -70,6 +70,10 @@
           expect(vaadinCheckbox.getAttribute('aria-checked')).to.be.eql('mixed');
         });
 
+        it('should set aria-checked to "false" when checked is set to null', () => {
+          vaadinCheckbox.checked = null;
+          expect(vaadinCheckbox.getAttribute('aria-checked')).to.eql('false');
+        });
       });
 
     });


### PR DESCRIPTION
Cherry-pick of #164 to `2.2` branch.