### PR TITLE
docs: add JSDoc for attributes [skip ci]

### DIFF
--- a/src/vaadin-checkbox-group.html
+++ b/src/vaadin-checkbox-group.html
@@ -141,6 +141,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * Error to show when the input value is invalid.
+             * @attr {string} error-message
              */
             errorMessage: {
               type: String,


### PR DESCRIPTION
Connected to vaadin/vaadin-core#257

Note, this is a PR for `2.4` branch. When cherry-picking it to master, we need to also include `helperText` property.