### PR TITLE
docs: remove mentions of iron-form [skip ci]

### DIFF
--- a/src/vaadin-checkbox-group.d.ts
+++ b/src/vaadin-checkbox-group.d.ts
@@ -104,7 +104,6 @@ declare class CheckboxGroupElement extends ThemableMixin(DirMixin(HTMLElement)) 
 
   /**
    * Returns true if `value` is valid.
-   * `<iron-form>` uses this to check the validity or all its elements.
    *
    * @returns True if the value is valid.
    */

--- a/src/vaadin-checkbox-group.js
+++ b/src/vaadin-checkbox-group.js
@@ -250,7 +250,6 @@ class CheckboxGroupElement extends ThemableMixin(DirMixin(PolymerElement)) {
 
   /**
    * Returns true if `value` is valid.
-   * `<iron-form>` uses this to check the validity or all its elements.
    *
    * @return {boolean} True if the value is valid.
    */


### PR DESCRIPTION
Let's remove this from JSDoc as we do it for other components as well.