### PR TITLE
chore: update JSDoc for custom events [skip ci]

### DIFF
--- a/src/vaadin-checkbox-group.d.ts
+++ b/src/vaadin-checkbox-group.d.ts
@@ -58,8 +58,8 @@ export interface CheckboxGroupEventMap extends HTMLElementEventMap, CheckboxGrou
  *
  * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
  *
- * @fires {CustomEvent<boolean>} invalid-changed
- * @fires {CustomEvent<Array<string>>} value-changed
+ * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
+ * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */
 declare class CheckboxGroupElement extends ThemableMixin(DirMixin(HTMLElement)) {
   /**

--- a/src/vaadin-checkbox.d.ts
+++ b/src/vaadin-checkbox.d.ts
@@ -56,8 +56,8 @@ export interface CheckboxEventMap extends HTMLElementEventMap, CheckboxElementEv
  *
  * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
  *
- * @fires {CustomEvent<boolean>} checked-changed
- * @fires {CustomEvent<boolean>} indeterminate-changed
+ * @fires {CustomEvent} checked-changed - Fired when the `checked` property changes.
+ * @fires {CustomEvent} indeterminate-changed - Fired when the `indeterminate` property changes.
  */
 declare class CheckboxElement extends ElementMixin(
   ControlStateMixin(ThemableMixin(GestureEventListeners(HTMLElement)))


### PR DESCRIPTION
Looks like the event type can not be inferred when using event name autocomplete provided by VSCode plugin. 
So I changed to use `@fires {CustomEvent}` without a type. Also, added the events descriptions.