### PR TITLE
test: cleanup duplicate unit tests

### DIFF
--- a/test/a11y.test.js
+++ b/test/a11y.test.js
@@ -9,24 +9,19 @@ describe('a11y', () => {
     checkbox = fixtureSync('<vaadin-checkbox>Vaadin <i>Checkbox</i></vaadin-checkbox>');
   });
 
-  it('should set aria-checked to "false" when indeterminate is first set to false, then checked is set to false', () => {
-    checkbox.checked = false;
-    expect(checkbox.getAttribute('aria-checked')).to.be.eql('false');
-  });
-
-  it('should set aria-checked to "false" when checked is first set to false, then indeterminate is set to false', () => {
-    checkbox.checked = false;
-    expect(checkbox.getAttribute('aria-checked')).to.be.eql('false');
-  });
-
-  it('should set aria-checked to "true" when indeterminate is first set to false, then checked is set to true', () => {
+  it('should set aria-checked to "true" when checked is set to true', () => {
     checkbox.checked = true;
     expect(checkbox.getAttribute('aria-checked')).to.be.eql('true');
   });
 
-  it('should set aria-checked to "true" when checked is first set to true, then indeterminate is set to false', () => {
-    checkbox.checked = true;
-    expect(checkbox.getAttribute('aria-checked')).to.be.eql('true');
+  it('should set aria-checked to "false" when checked is set to false', () => {
+    checkbox.checked = false;
+    expect(checkbox.getAttribute('aria-checked')).to.be.eql('false');
+  });
+
+  it('should set aria-checked to "mixed" when indeterminate is set to true', () => {
+    checkbox.indeterminate = true;
+    expect(checkbox.getAttribute('aria-checked')).to.be.eql('mixed');
   });
 
   it('should set aria-checked to "mixed" when indeterminate is first set to true, then checked is set to false', () => {

--- a/test/checkbox.test.js
+++ b/test/checkbox.test.js
@@ -103,21 +103,6 @@ describe('checkbox', () => {
     expect(checkbox.indeterminate).to.be.eql(false);
   });
 
-  it('should set aria-checked to "true" when checked', () => {
-    checkbox.checked = true;
-    expect(checkbox.getAttribute('aria-checked')).to.be.eql('true');
-  });
-
-  it('should set aria-checked to "false" when unchecked', () => {
-    checkbox.checked = false;
-    expect(checkbox.getAttribute('aria-checked')).to.be.eql('false');
-  });
-
-  it('should set aria-checked to "mixed" when indeterminate', () => {
-    checkbox.indeterminate = true;
-    expect(checkbox.getAttribute('aria-checked')).to.be.eql('mixed');
-  });
-
   it('should set indeterminate to false when clicked the first time', () => {
     checkbox.indeterminate = true;
 

--- a/test/checkbox.test.js
+++ b/test/checkbox.test.js
@@ -112,7 +112,7 @@ describe('checkbox', () => {
   });
 
   it('native checkbox should have the `presentation` role', () => {
-    expect(checkbox.getAttribute('role')).to.be.eql('checkbox');
+    expect(nativeCheckbox.getAttribute('role')).to.be.eql('presentation');
   });
 
   it('host should have the `checkbox` role', () => {


### PR DESCRIPTION
- After d7692ae144017af71b4629a7733a6fe219faf648 some tests became duplicate as they were testing the same thing. 
- One of the `role` tests was incorrect, updated to test the `presentation` role.