### PR TITLE
refactor: remove Safari 9 workaround

### DIFF
--- a/src/vaadin-checkbox-group.js
+++ b/src/vaadin-checkbox-group.js
@@ -372,9 +372,7 @@ class CheckboxGroupElement extends ThemableMixin(DirMixin(PolymerElement)) {
    * @protected
    */
   _containsFocus() {
-    const root = this.getRootNode();
-    // Safari 9 needs polyfilled `_activeElement` to return correct node
-    const activeElement = root._activeElement !== undefined ? root._activeElement : root.activeElement;
+    const activeElement = this.getRootNode().activeElement;
     return this.contains(activeElement);
   }
 

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -8,7 +8,7 @@ const config = {
     include: ['**/src/*'],
     threshold: {
       statements: 99,
-      branches: 86,
+      branches: 88,
       functions: 100,
       lines: 99
     }


### PR DESCRIPTION
The usage of polyfilled `_activeElement` is no longer needed and can be removed.