### PR TITLE
VS-4293 - Backport compact style support for Checkbox to Vaadin 14

### DIFF
--- a/theme/lumo/vaadin-checkbox-styles.html
+++ b/theme/lumo/vaadin-checkbox-styles.html
@@ -18,6 +18,12 @@
   <template>
     <style>
       :host {
+        color: var(--lumo-body-text-color);
+        font-size: var(--lumo-font-size-m);
+        font-family: var(--lumo-font-family);
+        line-height: var(--lumo-line-height-s);
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
         -webkit-tap-highlight-color: transparent;
         -webkit-user-select: none;
         -moz-user-select: none;
@@ -28,19 +34,20 @@
       }
 
       [part="label"]:not([empty]) {
-        margin: 0.1875em 0.875em 0.1875em 0.375em;
+        margin: var(--lumo-space-xs) var(--lumo-space-s) var(--lumo-space-xs) var(--lumo-space-xs);
       }
 
       [part="checkbox"] {
-        width: calc(1em + 2px);
-        height: calc(1em + 2px);
-        margin: 0.1875em;
+        width: calc(var(--lumo-size-m) / 2);
+        height: calc(var(--lumo-size-m) / 2);
+        margin: var(--lumo-space-xs);
         position: relative;
         border-radius: var(--lumo-border-radius-s);
         background-color: var(--lumo-contrast-20pct);
         transition: transform 0.2s cubic-bezier(.12, .32, .54, 2), background-color 0.15s;
         pointer-events: none;
         line-height: 1.2;
+        flex: none;
       }
 
       :host([indeterminate]) [part="checkbox"],
@@ -123,7 +130,7 @@
       /* RTL specific styles */
 
       :host([dir="rtl"]) [part="label"]:not([empty]) {
-        margin: 0.1875em 0.375em 0.1875em 0.875em;
+        margin: var(--lumo-space-xs) var(--lumo-space-s) var(--lumo-space-xs) var(--lumo-space-xs);
       }
     </style>
   </template>


### PR DESCRIPTION
## Description

When @JsModule("@vaadin/vaadin-lumo-styles/presets/compact.js") is used the checkbox compact style is not set, because lumo variables are missing in the style file. Applying the changes will correct the behavior and apply compact style to checkbox.
This issue has been fixed in Vaadin 22 https://github.com/vaadin/web-components/pull/2746 and has been requested to be applied to v14 too

Fixes # (issue)
VS-4293 Backport compact style support for Checkbox to Vaadin 14
## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it. 
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
