### PR TITLE
fix: prevent initial validation when checkbox-group is initialized as…

### DIFF
--- a/src/vaadin-checkbox-group.html
+++ b/src/vaadin-checkbox-group.html
@@ -135,10 +135,10 @@ This program is available under Apache License Version 2.0, available at https:/
             },
 
             /**
-             * Value of the checkbox group.
-             * Note: toggling the checkboxes modifies the value by creating new
-             * array each time, to override Polymer dirty-checking for arrays.
-             * You can still use Polymer array mutation methods to update the value.
+             * An array containing values of the currently checked checkboxes.
+             *
+             * The array is immutable so toggling checkboxes always results in
+             * creating a new array.
              * @type {!Array<!string>}
              */
             value: {

--- a/src/vaadin-checkbox-group.html
+++ b/src/vaadin-checkbox-group.html
@@ -326,7 +326,9 @@ This program is available under Apache License Version 2.0, available at https:/
             this.removeAttribute('has-value');
           }
 
+          const oldValue = this._oldValue;
           this._oldValue = value;
+
           // set a flag to avoid updating loop
           this._updatingValue = true;
           // reflect the value array to checkboxes
@@ -335,7 +337,9 @@ This program is available under Apache License Version 2.0, available at https:/
           });
           this._updatingValue = false;
 
-          this.validate();
+          if (oldValue !== undefined) {
+            this.validate();
+          }
         }
 
         /** @private */

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,14 +1,19 @@
 {
+  "parserOptions": {
+    "ecmaVersion": 8
+  },
   "globals": {
     "WCT": false,
     "describe": false,
     "beforeEach": false,
+    "afterEach": false,
     "fixture": false,
     "it": false,
     "sinon": false,
     "expect": false,
     "gemini": false,
     "MockInteractions": false,
-    "animationFrameFlush": false
+    "animationFrameFlush": false,
+    "nextRender": false
   }
 }

--- a/test/common.js
+++ b/test/common.js
@@ -1,0 +1,5 @@
+window.nextRender = async(element) => {
+  return new Promise(resolve => {
+    Polymer.RenderStatus.afterNextRender(element, resolve);
+  });
+};

--- a/test/test-suites.js
+++ b/test/test-suites.js
@@ -1,5 +1,6 @@
 window.VaadinCheckboxSuites = [
   'vaadin-checkbox_test.html',
   'vaadin-checkbox-group_test.html',
-  'accessibility.html'
+  'accessibility.html',
+  'validation.html'
 ];

--- a/test/vaadin-checkbox-group_test.html
+++ b/test/vaadin-checkbox-group_test.html
@@ -10,6 +10,7 @@
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../vaadin-checkbox.html">
   <link rel="import" href="../vaadin-checkbox-group.html">
+  <script src="common.js"></script>
 </head>
 
 <body>
@@ -492,6 +493,41 @@
       expect(vaadinCheckboxGroup.shadowRoot.querySelector('[part="error-message"]').getAttribute('aria-hidden')).to.be.equal('false');
     });
 
+  });
+
+  describe('initial validation', () => {
+    let validateSpy;
+    let group;
+
+    beforeEach(() => {
+      group = document.createElement('vaadin-checkbox-group');
+      validateSpy = sinon.spy(group, 'validate');
+    });
+
+    afterEach(() => {
+      group.remove();
+    });
+
+    it('should not validate by default', async() => {
+      document.body.appendChild(group);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value', async() => {
+      group.value = ['en'];
+      document.body.appendChild(group);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value and invalid', async() => {
+      group.value = ['en'];
+      group.invalid = true;
+      document.body.appendChild(group);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
   });
 
   describe('vaadin-checkbox-group value array mutation methods', () => {

--- a/test/vaadin-checkbox-group_test.html
+++ b/test/vaadin-checkbox-group_test.html
@@ -10,7 +10,6 @@
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../vaadin-checkbox.html">
   <link rel="import" href="../vaadin-checkbox-group.html">
-  <script src="common.js"></script>
 </head>
 
 <body>
@@ -493,41 +492,6 @@
       expect(vaadinCheckboxGroup.shadowRoot.querySelector('[part="error-message"]').getAttribute('aria-hidden')).to.be.equal('false');
     });
 
-  });
-
-  describe('initial validation', () => {
-    let validateSpy;
-    let group;
-
-    beforeEach(() => {
-      group = document.createElement('vaadin-checkbox-group');
-      validateSpy = sinon.spy(group, 'validate');
-    });
-
-    afterEach(() => {
-      group.remove();
-    });
-
-    it('should not validate by default', async() => {
-      document.body.appendChild(group);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
-
-    it('should not validate when the field has an initial value', async() => {
-      group.value = ['en'];
-      document.body.appendChild(group);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
-
-    it('should not validate when the field has an initial value and invalid', async() => {
-      group.value = ['en'];
-      group.invalid = true;
-      document.body.appendChild(group);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
   });
 
   describe('vaadin-checkbox-group value array mutation methods', () => {

--- a/test/validation.html
+++ b/test/validation.html
@@ -1,0 +1,50 @@
+<!doctype html>
+
+<head>
+    <meta charset="UTF-8">
+    <title>vaadin-checkbox-group tests</title>
+    <script src="../../web-component-tester/browser.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <link rel="import" href="../../iron-test-helpers/mock-interactions.html">
+    <link rel="import" href="../vaadin-checkbox-group.html">
+    <script src="common.js"></script>
+</head>
+
+<body>
+<script>
+  describe('initial validation', () => {
+    let validateSpy;
+    let group;
+
+    beforeEach(() => {
+      group = document.createElement('vaadin-checkbox-group');
+      validateSpy = sinon.spy(group, 'validate');
+    });
+
+    afterEach(() => {
+      group.remove();
+    });
+
+    it('should not validate by default', async () => {
+      document.body.appendChild(group);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value', async () => {
+      group.value = ['en'];
+      document.body.appendChild(group);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value and invalid', async () => {
+      group.value = ['en'];
+      group.invalid = true;
+      document.body.appendChild(group);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+  });
+</script>
+</body>

--- a/test/validation.html
+++ b/test/validation.html
@@ -25,20 +25,20 @@
       group.remove();
     });
 
-    it('should not validate by default', async () => {
+    it('should not validate by default', async() => {
       document.body.appendChild(group);
       await nextRender();
       expect(validateSpy.called).to.be.false;
     });
 
-    it('should not validate when the field has an initial value', async () => {
+    it('should not validate when the field has an initial value', async() => {
       group.value = ['en'];
       document.body.appendChild(group);
       await nextRender();
       expect(validateSpy.called).to.be.false;
     });
 
-    it('should not validate when the field has an initial value and invalid', async () => {
+    it('should not validate when the field has an initial value and invalid', async() => {
       group.value = ['en'];
       group.invalid = true;
       document.body.appendChild(group);


### PR DESCRIPTION
Backports web-components#4153 as part of an EoD task


> ## Description
> The PR prevents the initial validation that could previously take place when `checkbox-group` is initially provided with a non-empty value and is initially marked `invalid`.
> 
> Part of #4150
> 
> ## Type of change
> * [x]  Bugfix
> 
> ## Checklist
> * [x]  I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
> * [x]  I have added a description following the guideline.
> * [x]  The issue is created in the corresponding repository and I have referenced it.
> * [x]  I have added tests to ensure my change is effective and works as intended.
> * [x]  New and existing tests are passing locally with my change.
> * [x]  I have performed self-review and corrected misspellings.

