### PR TITLE
feat: fire a validated event on validation and add shouldSetInvalid method

### DIFF
--- a/src/vaadin-checkbox-group.html
+++ b/src/vaadin-checkbox-group.html
@@ -258,6 +258,7 @@ This program is available under Apache License Version 2.0, available at https:/
          */
         validate() {
           this.invalid = this.required && this.value.length === 0;
+          this.dispatchEvent(new CustomEvent('validated', {detail: {valid: !this.invalid}}));
           return !this.invalid;
         }
 

--- a/src/vaadin-checkbox-group.html
+++ b/src/vaadin-checkbox-group.html
@@ -251,13 +251,34 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         /**
+         * @param {boolean} invalid
+         * @protected
+         */
+        _setInvalid(invalid) {
+          if (this._shouldSetInvalid(invalid)) {
+            this.invalid = invalid;
+          }
+        }
+
+        /**
+         * Override this method to define whether the given `invalid` state should be set.
+         *
+         * @param {boolean} _invalid
+         * @return {boolean}
+         * @protected
+         */
+        _shouldSetInvalid(_invalid) {
+          return true;
+        }
+
+        /**
          * Returns true if `value` is valid.
          * `<iron-form>` uses this to check the validity or all its elements.
          *
          * @return {boolean} True if the value is valid.
          */
         validate() {
-          this.invalid = this.required && this.value.length === 0;
+          this._setInvalid(this.required && this.value.length === 0);
           this.dispatchEvent(new CustomEvent('validated', {detail: {valid: !this.invalid}}));
           return !this.invalid;
         }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,4 +1,7 @@
 {
+  "parserOptions": {
+    "ecmaVersion": 8
+  },
   "globals": {
     "WCT": false,
     "describe": false,

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -2,6 +2,10 @@
   "parserOptions": {
     "ecmaVersion": 8
   },
+  "rules": {
+    "no-undef": 0,
+    "no-unused-vars": 0
+  },
   "globals": {
     "WCT": false,
     "describe": false,

--- a/test/invalid-common.js
+++ b/test/invalid-common.js
@@ -1,0 +1,48 @@
+const cachedWrappers = [];
+const templates = {};
+/**
+ * Creates a wrapper as a direct child of `<body>` to put the tested element into.
+ * Need to be in the DOM to test for example `connectedCallback()` on elements.
+ *
+ * @param {!Element} parentNode
+ * @return {Element} wrapping node
+ */
+function fixtureWrapper(parentNode = document.createElement('div')) {
+  document.body.appendChild(parentNode);
+  cachedWrappers.push(parentNode);
+  return parentNode;
+}
+
+// # sourceMappingURL=fixture-wrapper.js.map
+
+/**
+ * Creates a `<template>` element from a provided string template.
+ *
+ * @param {string} html
+ * @return {HTMLTemplateElement}
+ */
+function template(html) {
+  let tpl = templates[html];
+  if (!tpl) {
+    tpl = document.createElement('template');
+    tpl.innerHTML = html;
+    templates[html] = tpl;
+  }
+  return tpl;
+}
+/**
+ * Setups an element synchronously from the provided string template and puts it in the DOM.
+ * Uses `document.importNode` to ensure proper custom elements upgrade timings.
+ *
+ * @template {Element} T - Is an element or a node
+ * @param {!string} html
+ * @param {Element=} wrapper
+ * @return {T}
+ */
+function fixtureSync(html, wrapper) {
+  const tpl = template(html);
+  const parentNode = fixtureWrapper(wrapper);
+  parentNode.appendChild(document.importNode(tpl.content, true));
+  return parentNode.firstElementChild;
+}
+// # sourceMappingURL=fixture-no-side-effect.js.map

--- a/test/invalid-common.js
+++ b/test/invalid-common.js
@@ -13,8 +13,6 @@ function fixtureWrapper(parentNode = document.createElement('div')) {
   return parentNode;
 }
 
-// # sourceMappingURL=fixture-wrapper.js.map
-
 /**
  * Creates a `<template>` element from a provided string template.
  *
@@ -45,4 +43,3 @@ function fixtureSync(html, wrapper) {
   parentNode.appendChild(document.importNode(tpl.content, true));
   return parentNode.firstElementChild;
 }
-// # sourceMappingURL=fixture-no-side-effect.js.map

--- a/test/vaadin-checkbox-group_test.html
+++ b/test/vaadin-checkbox-group_test.html
@@ -10,6 +10,7 @@
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../vaadin-checkbox.html">
   <link rel="import" href="../vaadin-checkbox-group.html">
+  <script src="invalid-common.js"></script>
 </head>
 
 <body>
@@ -605,6 +606,31 @@
       expect(wrappedCheckboxes).not.be.empty;
       expect(wrappedCheckboxes[0].getBoundingClientRect().left)
         .to.equal(firstLeft);
+    });
+  });
+
+  describe('check-box invalid', () => {
+    let element;
+  
+    function nextRender(element) {
+      return new Promise(resolve => {
+        Polymer.RenderStatus.afterNextRender(element, resolve);
+      });
+    }
+  
+    beforeEach(async() => {
+      element = fixtureSync('<vaadin-checkbox-group></vaadin-checkbox-group>');
+      element._shouldSetInvalid = (invalid) => invalid;
+      await nextRender();
+    });
+
+    it('should set invalid only when it is true', async() => {
+      element.required = true;
+      element.validate();
+      expect(element.invalid).to.be.true;
+      element.value = 'value';
+      element.validate();
+      expect(element.invalid).to.be.true;
     });
   });
 </script>

--- a/test/vaadin-checkbox-group_test.html
+++ b/test/vaadin-checkbox-group_test.html
@@ -492,6 +492,28 @@
       expect(vaadinCheckboxGroup.shadowRoot.querySelector('[part="error-message"]').getAttribute('aria-hidden')).to.be.equal('false');
     });
 
+    it('should fire a validated event on validation success', () => {
+      const validatedSpy = sinon.spy();
+      vaadinCheckboxGroup.addEventListener('validated', validatedSpy);
+      vaadinCheckboxGroup.validate();
+
+      expect(validatedSpy.calledOnce).to.be.true;
+      const event = validatedSpy.firstCall.args[0];
+      expect(event.detail.valid).to.be.true;
+    });
+
+    it('should fire a validated event on validation failure', () => {
+      const validatedSpy = sinon.spy();
+      vaadinCheckboxGroup.addEventListener('validated', validatedSpy);
+      vaadinCheckboxGroup.required = true;
+      vaadinCheckboxGroup.validate();
+
+      expect(validatedSpy.calledOnce).to.be.true;
+      const event = validatedSpy.firstCall.args[0];
+      expect(event.detail.valid).to.be.false;
+    });
+
+
   });
 
   describe('vaadin-checkbox-group value array mutation methods', () => {

--- a/test/vaadin-checkbox-group_test.html
+++ b/test/vaadin-checkbox-group_test.html
@@ -628,7 +628,7 @@
       element.required = true;
       element.validate();
       expect(element.invalid).to.be.true;
-      element.value = 'value';
+      element.value = ['value'];
       element.validate();
       expect(element.invalid).to.be.true;
     });


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

1.Fires a validated event when the web component's validation takes place.
2.Adds a protected shouldSetInvalid() method. It will be used for preventing the web component from modifying the client-side invalid state on the Flow side afterward.

Fixes # (issue)

## Type of change

- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
