### PR TITLE
fix: call click on checkbox Space key up

### DIFF
--- a/src/vaadin-checkbox.html
+++ b/src/vaadin-checkbox.html
@@ -265,12 +265,8 @@ This program is available under Apache License Version 2.0, available at https:/
           this.addEventListener('keyup', e => {
             if (this.__interactionsAllowed(e) && e.keyCode === 32) {
               e.preventDefault();
-              this._toggleChecked();
+              this.click();
               this.removeAttribute('active');
-
-              if (this.indeterminate) {
-                this.indeterminate = false;
-              }
             }
           });
         }

--- a/test/vaadin-checkbox_test.html
+++ b/test/vaadin-checkbox_test.html
@@ -228,6 +228,16 @@
         expect(vaadinCheckbox.getAttribute('aria-checked')).to.be.eql('true');
       });
 
+      it('should fire click event on space key press', () => {
+        const spy = sinon.spy();
+        vaadinCheckbox.addEventListener('click', spy);
+
+        MockInteractions.keyDownOn(vaadinCheckbox, 32);
+        MockInteractions.keyUpOn(vaadinCheckbox, 32);
+
+        expect(spy).to.be.calledOnce;
+      });
+
       it('should not be checked after space when initially checked is true and indeterminate is true', () => {
         vaadinCheckbox.checked = true;
         vaadinCheckbox.indeterminate = true;


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/6737

This change adds manual `click()` call on `keyup` event for better backwards compatibility.

Alternatively, we could just remove `event.preventDefault()` from `keydown` and `keyup` listeners. 
This enables native `click` event to be fired on <kbd>Space</kbd> key press, at least in modern browsers.

## Type of change

- Bugfix